### PR TITLE
implementing UDEV rule to display serial devices as /dev/ttyIOTA0 and /dev/ttyIOTA1

### DIFF
--- a/Hologram/Network/Modem/IOTA.py
+++ b/Hologram/Network/Modem/IOTA.py
@@ -12,8 +12,8 @@ from ModemMode import Serial
 from Modem import Modem
 from ...Event import Event
 
-IOTA_PPP_DEVICE_NAME = '/dev/ttyACM0'
-IOTA_SERIAL_DEVICE_NAME = '/dev/ttyACM1'
+IOTA_PPP_DEVICE_NAME = '/dev/ttyIOTA0'
+IOTA_SERIAL_DEVICE_NAME = '/dev/ttyIOTA1'
 DEFAULT_IOTA_TIMEOUT = 200
 
 class IOTA(Modem):

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ If everything goes well, you’re done and ready to use the SDK.
 2. `scripts` -  This directory contains example Python scripts that utilize the Python SDK.
 3. `Hologram` - This directory contains all the Hologram class interfaces.
 4. `Exceptions` - This directory stores our custom `Exception` used in the SDK.
+5. `rules` - This directory contains the UDEV rule for the IOTA dongle
 
 You can also find more documentation [here](https://hologram.io/docs/reference/cloud/python-sdk).
 

--- a/rules/83-ublox-iota.rules
+++ b/rules/83-ublox-iota.rules
@@ -1,0 +1,2 @@
+KERNEL=="ttyACM[0-9]*", SUBSYSTEM=="tty", ATTRS{iad_bFirstInterface}=="00", ENV{ID_VENDOR_ID}=="1546", ENV{ID_MODEL_ID}=="1102", SYMLINK+="ttyIOTA0"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEM=="tty", ATTRS{iad_bFirstInterface}=="02", ENV{ID_VENDOR_ID}=="1546", ENV{ID_MODEL_ID}=="1102", SYMLINK+="ttyIOTA1"


### PR DESCRIPTION
implementing such rule makes the IOTA discovering easier than the regular way especially when multiple serial devices are plugged into the host PC (i.e. other serial modems, DYI boards and so on)