### PR TITLE
Strip AT command result prefix when issued command ends with ? or %

### DIFF
--- a/Hologram/Network/Modem/Modem.py
+++ b/Hologram/Network/Modem/Modem.py
@@ -697,11 +697,14 @@ class Modem(IModem):
 
     #returns the raw result of a command, with the 'CMD: ' prefix stripped
     def _basic_command(self, cmd, prefix=True):
+        base_cmd = cmd.rstrip('?').rstrip('%')
         try:
             ok, r = self.command(cmd)
             if ok == ModemResult.OK:
                 if prefix and r.startswith(cmd+': '):
                     return r.lstrip(cmd + ': ')
+                elif prefix and r.startswith(base_cmd+': '):
+                    return r.lstrip(base_cmd + ': ')
                 else:
                     return r
         except AttributeError as e:

--- a/Hologram/Network/Modem/Modem.py
+++ b/Hologram/Network/Modem/Modem.py
@@ -697,7 +697,7 @@ class Modem(IModem):
 
     #returns the raw result of a command, with the 'CMD: ' prefix stripped
     def _basic_command(self, cmd, prefix=True):
-        base_cmd = cmd.rstrip('?').rstrip('%')
+        base_cmd = cmd.rstrip('?%')
         try:
             ok, r = self.command(cmd)
             if ok == ModemResult.OK:


### PR DESCRIPTION
When issuing an AT command to the modem which ends in a `?` or `%`, the prefix of the result may not contain the last character, which prevents existing stripping logic from working.  For example, `+CREG?` might return something like `CREG: 2,1,"11BE","D787762",6`.  With this PR, Modem._basic_command will instead return `2,1,"11BE","D787762",6`, the raw data, consistent with what is returned for commands without the `?` or `%`.