### PR TITLE
move ublox specific URCs to nova base class

### DIFF
--- a/Hologram/Network/Modem/Modem.py
+++ b/Hologram/Network/Modem/Modem.py
@@ -393,46 +393,16 @@ class Modem(IModem):
 
     # EFFECTS: Handles URC related AT command responses.
     def handleURC(self, urc):
-        self.logger.debug("URC! %s",  urc)
+        self.logger.debug("URC! %s", urc)
         self.logger.debug("handleURC state: %d",  self.urc_state)
-
-        next_urc_state = self.urc_state
 
         if urc.startswith("+CMTI: "):
             self._handle_sms_receive_urc(urc)
-        elif urc.startswith('+UULOC: '):
-            self._handle_location_urc(urc)
-        elif urc.startswith('+UUSORD: '):
-
-            # Strip UUSORD socket identifier + payload length from the URC event.
-            # Example: {+UUSORD: 0,2} -> 0 and 2
-            response_list = urc.lstrip('+UUSORD: ').split(',')
-            socket_identifier = int(response_list[0])
-            payload_length = int(response_list[-1])
-
-            if self.urc_state == Modem.SOCKET_RECEIVE_READ:
-                self._read_and_append_message_receive_buffer(socket_identifier, payload_length)
-            else:
-                self.socket_identifier = socket_identifier
-                self.last_read_payload_length = payload_length
-                next_urc_state = Modem.SOCKET_SEND_READ
-        elif urc.startswith('+UUSOLI: '):
-            self._handle_listen_urc(urc)
-            self.last_read_payload_length = 0
-            next_urc_state = Modem.SOCKET_RECEIVE_READ
-        elif urc.startswith('+UUPSDD: '):
-            self.event.broadcast('cellular.forced_disconnect')
-        elif urc.startswith('+UUSOCL: '):
-            next_urc_state = Modem.SOCKET_CLOSED
         else:
             self.logger.debug("URC was not handled. \'%s\'",  urc)
 
-        self.urc_state = next_urc_state
-
 
     # URC handlers
-
-
     def _handle_sms_receive_urc(self, urc):
         self.event.broadcast('sms.received')
 

--- a/Hologram/Network/Modem/Nova.py
+++ b/Hologram/Network/Modem/Nova.py
@@ -27,6 +27,48 @@ class Nova(Modem):
     def enable_at_sockets_mode(self):
         self._at_sockets_available = True
 
+    def handleURC(self, urc):
+        """
+        Handles UBlox URC related AT command responses.
+
+        :param urc: the URC string
+        :type urc: string
+        """
+        self.logger.debug("URC! %s", urc)
+
+        if urc.startswith('+CSIM: '):
+            self.parse_and_populate_last_sim_otp_response(urc.lstrip('+CSIM: '))
+            return
+        elif urc.startswith('+UULOC: '):
+            self._handle_location_urc(urc)
+        elif urc.startswith('+UUSORD: '):
+
+            # Strip UUSORD socket identifier + payload length from the URC event.
+            # Example: {+UUSORD: 0,2} -> 0 and 2
+            response_list = urc.lstrip('+UUSORD: ').split(',')
+            socket_identifier = int(response_list[0])
+            payload_length = int(response_list[-1])
+
+            if self.urc_state == Modem.SOCKET_RECEIVE_READ:
+                self._read_and_append_message_receive_buffer(socket_identifier, payload_length)
+            else:
+                self.socket_identifier = socket_identifier
+                self.last_read_payload_length = payload_length
+                self.urc_state = Modem.SOCKET_SEND_READ
+        elif urc.startswith('+UUSOLI: '):
+            self._handle_listen_urc(urc)
+            self.last_read_payload_length = 0
+            self.urc_state = Modem.SOCKET_RECEIVE_READ
+        elif urc.startswith('+UUPSDD: '):
+            self.event.broadcast('cellular.forced_disconnect')
+        elif urc.startswith('+UUSOCL: '):
+            self.urc_state = Modem.SOCKET_CLOSED
+
+        super().handleURC(urc)
+
+    def parse_and_populate_last_sim_otp_response(self, response):
+        raise NotImplementedError('Must instantiate the right modem type')
+
     @property
     def version(self):
         return self._basic_command('I9')

--- a/Hologram/Network/Modem/Nova_U201.py
+++ b/Hologram/Network/Modem/Nova_U201.py
@@ -95,14 +95,6 @@ class Nova_U201(Nova):
 
         return self.last_sim_otp_command_response
 
-    # EFFECTS: Handles URC related AT command responses.
-    def handleURC(self, urc):
-        if urc.startswith('+CSIM: '):
-            self.parse_and_populate_last_sim_otp_response(urc.lstrip('+CSIM: '))
-            return
-
-        super().handleURC(urc)
-
     def populate_location_obj(self, response):
         response_list = response.split(',')
         self.last_location = Location(*response_list)


### PR DESCRIPTION
A lot of the URCs in the modem base class are specific for UBlox modems so they should be processed in the proper class