### PR TITLE
Allow different PDP contexts

### DIFF
--- a/Hologram/Network/Modem/Quectel.py
+++ b/Hologram/Network/Modem/Quectel.py
@@ -19,11 +19,11 @@ from Exceptions.HologramError import SerialError, NetworkError
 
 class Quectel(Modem):
 
-    def __init__(self, device_name=None, baud_rate='9600',
-                 chatscript_file=None, event=Event()):
+    def __init__(self, device_name=None, baud_rate='9600', chatscript_file=None, 
+                 event=Event(), apn='hologram', pdp_context=1):
 
-        super().__init__(device_name=device_name, baud_rate=baud_rate,
-                            chatscript_file=chatscript_file, event=event)
+        super().__init__(device_name=device_name, baud_rate=baud_rate, chatscript_file=chatscript_file, 
+                         event=event, apn=apn, pdp_context=pdp_context)
         self._at_sockets_available = True
         self.urc_response = ''
 
@@ -152,8 +152,8 @@ class Quectel(Modem):
     def _set_up_pdp_context(self):
         if self._is_pdp_context_active(): return True
         self.logger.info('Setting up PDP context')
-        self.set('+QICSGP', f'1,1,\"{self._apn}\",\"\",\"\",1')
-        ok, _ = self.set('+QIACT', '1', timeout=30)
+        self.set('+QICSGP', f'{self._pdp_context},1,\"{self._apn}\",\"\",\"\",1')
+        ok, _ = self.set('+QIACT', f'{self._pdp_context}', timeout=30)
         if ok != ModemResult.OK:
             self.logger.error('PDP Context setup failed')
             raise NetworkError('Failed PDP context setup')

--- a/tests/Modem/test_BG96.py
+++ b/tests/Modem/test_BG96.py
@@ -6,7 +6,7 @@
 #
 # test_BG96.py - This file implements unit tests for the BG96 modem interface.
 
-from unittest.mock import patch
+from unittest.mock import patch, call
 import pytest
 import sys
 
@@ -72,3 +72,25 @@ def test_close_socket(mock_pdp, mock_command, mock_set, no_serial_port):
     modem.close_socket()
     mock_set.assert_called_with("+QIACT", "0", timeout=30)
     mock_command.assert_called_with("+QICLOSE", 1)
+
+@patch.object(BG96, "set")
+def test_set_up_pdp_context_default(mock_set, no_serial_port):
+    modem = BG96()
+    mock_set.return_value = (ModemResult.OK, None)
+
+    modem._set_up_pdp_context()
+
+    expected_calls = [call('+QICSGP', '1,1,\"hologram\",\"\",\"\",1'), 
+                      call('+QIACT', '1', timeout=30)]
+    mock_set.assert_has_calls(expected_calls, any_order=True)
+
+@patch.object(BG96, "set")
+def test_set_up_pdp_context_custom_apn_and_pdp_context(mock_set, no_serial_port):
+    modem = BG96(apn='hologram2', pdp_context=3)
+    mock_set.return_value = (ModemResult.OK, None)
+
+    modem._set_up_pdp_context()
+
+    expected_calls = [call('+QICSGP', '3,1,\"hologram2\",\"\",\"\",1'), 
+                      call('+QIACT', '3', timeout=30)]
+    mock_set.assert_has_calls(expected_calls, any_order=True)

--- a/tests/Modem/test_Modem.py
+++ b/tests/Modem/test_Modem.py
@@ -6,6 +6,7 @@
 #
 # test_Modem.py - This file implements unit tests for the Modem class.
 
+from unittest.mock import patch, call
 import pytest
 import sys
 from datetime import datetime
@@ -47,6 +48,9 @@ def mock_command_sms(modem, at_command):
 def mock_set_sms(modem, at_command, val):
     return None
 
+def mock_inactive_pdp_context(modem):
+    return False
+
 @pytest.fixture
 def no_serial_port(monkeypatch):
     monkeypatch.setattr(Modem, '_read_from_serial_port', mock_read)
@@ -56,6 +60,7 @@ def no_serial_port(monkeypatch):
     monkeypatch.setattr(Modem, 'openSerialPort', mock_open_serial_port)
     monkeypatch.setattr(Modem, 'closeSerialPort', mock_close_serial_port)
     monkeypatch.setattr(Modem, 'detect_usable_serial_port', mock_detect_usable_serial_port)
+    monkeypatch.setattr(Modem, '_is_pdp_context_active', mock_inactive_pdp_context)
 
 @pytest.fixture
 def get_sms(monkeypatch):
@@ -75,6 +80,8 @@ def test_init_modem_no_args(no_serial_port):
     assert(modem.chatscript_file.endswith('/chatscripts/default-script'))
     assert(modem._at_sockets_available == False)
     assert(modem.description == 'Modem')
+    assert(modem.apn == 'hologram')
+    assert(modem.pdp_context == 1)
 
 def test_init_modem_chatscriptfileoverride(no_serial_port):
     modem = Modem(chatscript_file='test-chatscript')
@@ -82,6 +89,14 @@ def test_init_modem_chatscriptfileoverride(no_serial_port):
     assert(modem.socket_identifier == 0)
     assert(modem.chatscript_file == 'test-chatscript')
 
+def test_init_modem_apn(no_serial_port):
+    modem = Modem(apn='hologram2')
+    assert(modem.apn == 'hologram2')
+    
+def test_init_modem_pdp_context(no_serial_port):
+    modem = Modem(pdp_context=3)
+    assert(modem.pdp_context == 3)
+    
 def test_get_result_string(no_serial_port):
     modem = Modem()
     assert(modem.getResultString(0) == 'Modem returned OK')
@@ -97,6 +112,31 @@ def test_get_location(no_serial_port):
     with pytest.raises(NotImplementedError) as e:
         assert(modem.location == 'test location')
         assert('This modem does not support this property' in str(e))
+
+@patch.object(Modem, "set")
+def test_set_up_pdp_context_default(mock_set, no_serial_port):
+    modem = Modem()
+    mock_set.return_value = (ModemResult.OK, None)
+
+    modem._set_up_pdp_context()
+
+    expected_calls = [call('+UPSD', '0,1,\"hologram\"'), 
+                      call('+UPSD', '0,7,\"0.0.0.0\"'), 
+                      call('+UPSDA', '0,3', timeout=30)]
+    mock_set.assert_has_calls(expected_calls, any_order=True)
+
+@patch.object(Modem, "set")
+def test_set_up_pdp_context_custom_apn_and_pdp_context(mock_set, no_serial_port):
+    modem = Modem(apn='hologram2', pdp_context=3)
+    mock_set.return_value = (ModemResult.OK, None)
+
+    modem._set_up_pdp_context()
+
+    expected_calls = [call('+UPSD', '0,100,3'),
+                      call('+UPSD', '0,1,\"hologram2\"'), 
+                      call('+UPSD', '0,7,\"0.0.0.0\"'), 
+                      call('+UPSDA', '0,3', timeout=30)]
+    mock_set.assert_has_calls(expected_calls, any_order=True)
 
 # SMS
 


### PR DESCRIPTION
- Add `apn` and `pdp_context` attributes to Modem constructors adding existing default values
- Update AT commands to leverage the new properties
- Was able to test `apn` and `pdp_context` properties with an actual BG96, seeing the changes reflected with a `+CDGCONT`